### PR TITLE
#45 feat: mypage > 결제 취소 UI 구현

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import {
   useNavigationType,
   useLocation,
   matchPath,
+  Navigate,
 } from 'react-router-dom';
 import { useHeaderStore } from './state/client/useHeaderStore';
 import { useSideMenuStore } from './state/client/useSideMenuStore';
@@ -84,7 +85,7 @@ function App() {
       setTitle(<img src={logoimage} alt="로고" width="54" height="19" />);
       setShowBackButton(false);
       setShowMenuButton(true);
-    } else if (matchPath('/mypage', pathname)) {
+    } else if (matchPath('/mypage/:tab', pathname)) {
       setUseHeader(true);
       setTitle('마이페이지');
       setShowBackButton(true);
@@ -109,6 +110,11 @@ function App() {
       setTitle('서비스결제');
       setShowBackButton(true);
       setShowMenuButton(false);
+    } else if (matchPath('/cancel-payment', pathname)) {
+      setUseHeader(true);
+      setTitle('취소 요청');
+      setShowBackButton(true);
+      setShowMenuButton(false);
     } else {
       setUseHeader(false);
     }
@@ -131,7 +137,11 @@ function App() {
     <Layout>
       <Routes>
         <Route path="/" element={<Homepage />} />
-        <Route path="/mypage" element={<Mypage />} />
+        <Route
+          path="/mypage"
+          element={<Navigate to="/mypage/account" replace />}
+        />
+        <Route path="/mypage/:tab" element={<Mypage />} />
         <Route path="/login" element={<Login />} />
         <Route path="/terms" element={<Terms />} />
         <Route path="/signup" element={<Signup />} />

--- a/frontend/src/assets/icons/plus.svg
+++ b/frontend/src/assets/icons/plus.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
+  <path d="M9.86353 2L9.86352 18" stroke="#6314E4" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M1.5 10L17.5 10" stroke="#6314E4" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/frontend/src/assets/icons/remove.svg
+++ b/frontend/src/assets/icons/remove.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 18 18" fill="none">
+  <path d="M9 17C13.4183 17 17 13.4183 17 9C17 4.58172 13.4183 1 9 1C4.58172 1 1 4.58172 1 9C1 13.4183 4.58172 17 9 17Z" fill="#D8D8D8" stroke="#8B8B8B" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M13 5L5 13" stroke="#8B8B8B" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M5 5L13 13" stroke="#8B8B8B" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/components/atom/Button/Button.tsx
+++ b/frontend/src/components/atom/Button/Button.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import styles from './Button.module.css';
+import PlusIcon from '@/assets/icons/plus.svg?react';
 
 export type ButtonSize = 'size1' | 'size2' | 'size3' | 'size4';
 export type ButtonVariant =
@@ -31,6 +32,7 @@ export function Button({
 
   return (
     <button className={buttonClass} onClick={onClick} {...props}>
+      {variant === 'plus_icon' && <PlusIcon />}
       {children}
     </button>
   );

--- a/frontend/src/components/atom/Input/Input.tsx
+++ b/frontend/src/components/atom/Input/Input.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, MouseEventHandler } from 'react';
 import styles from './Input.module.css';
 
 interface InputProps
@@ -7,6 +7,7 @@ interface InputProps
   className?: string;
   type?: 'text' | 'password' | 'email' | 'number' | 'tel' | 'url';
   onChange?: (value: string) => void;
+  onChangeObj?: (id: string, value: string) => void;
 }
 
 export function Input({
@@ -16,6 +17,7 @@ export function Input({
   type = 'text',
   value: propValue,
   onChange,
+  onChangeObj,
   ...props
 }: InputProps) {
   const [isFocused, setIsFocused] = useState(false);
@@ -32,14 +34,18 @@ export function Input({
   const handleBlur = () => setIsFocused(false);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newValue = e.target.value;
+    const { id, value: newValue } = e.target;
     setInputValue(newValue);
     if (onChange) {
       onChange(newValue);
     }
+    if (onChangeObj) {
+      onChangeObj(id, newValue);
+    }
   };
 
-  const clearInput = () => {
+  const clearInput: MouseEventHandler<HTMLButtonElement> = (e) => {
+    const target = e.target as HTMLButtonElement;
     setInputValue('');
     if (inputRef.current) {
       inputRef.current.value = '';
@@ -47,6 +53,9 @@ export function Input({
     }
     if (onChange) {
       onChange('');
+    }
+    if (onChangeObj) {
+      onChangeObj(target.id, '');
     }
   };
 
@@ -75,6 +84,7 @@ export function Input({
         />
         {inputValue && !disabled && type !== 'password' && (
           <button
+            id={id}
             type="button"
             className={styles.clearButton}
             onClick={clearInput}

--- a/frontend/src/components/molecule/InputBox/InputBox.tsx
+++ b/frontend/src/components/molecule/InputBox/InputBox.tsx
@@ -21,6 +21,7 @@ interface InputBoxProps
   buttonClassName?: string;
   buttonText?: string;
   onChange?: (value: string) => void;
+  onChangeObj?: (id: string, value: string) => void;
   onClick?: () => void;
 }
 
@@ -38,6 +39,7 @@ export function InputBox({
   buttonClassName,
   buttonText,
   onChange,
+  onChangeObj,
   onClick,
   ...props
 }: InputBoxProps) {
@@ -51,6 +53,7 @@ export function InputBox({
           disabled={disabled}
           type={type}
           onChange={onChange}
+          onChangeObj={onChangeObj}
           {...props}
         />
         {buttonText && (

--- a/frontend/src/components/molecule/PhoneVerificationForm/PhoneVerificationForm.tsx
+++ b/frontend/src/components/molecule/PhoneVerificationForm/PhoneVerificationForm.tsx
@@ -2,20 +2,22 @@ import { useState } from 'react';
 import { InputBox } from '@/components/molecule/InputBox';
 import styles from './PhoneVerificationForm.module.css';
 
-export function PhoneVerificationForm() {
-  const [phoneNumber, setPhoneNumber] = useState('');
+interface PhoneVerificationFormProps {
+  phoneNumber: string;
+  onChangeObj?: (id: string, value: string) => void;
+}
+
+export function PhoneVerificationForm({
+  phoneNumber,
+  onChangeObj,
+}: PhoneVerificationFormProps) {
   const [phoneNumberMessage, setPhoneNumberMessage] = useState('');
 
   const [verificationCode, setVerificationCode] = useState('');
   const [verificationCodeMessage, setVerificationCodeMessage] = useState('');
 
-  const handlePhoneNumberChange = (value: string) => {
-    setPhoneNumber(value);
-    console.log('휴대폰 번호 정책 확인');
-  };
-
   const handleVerificationCodeChange = (value: string) => {
-    setPhoneNumber(value);
+    setVerificationCode(value);
     console.log('인증번호 정책 확인');
   };
   return (
@@ -28,7 +30,7 @@ export function PhoneVerificationForm() {
         buttonSize="size4"
         buttonVariant="default"
         buttonText="인증번호 발송"
-        onChange={handlePhoneNumberChange}
+        onChangeObj={onChangeObj}
       />
       <div className={styles.inputGroup}>
         <InputBox

--- a/frontend/src/components/organism/Account/Account.tsx
+++ b/frontend/src/components/organism/Account/Account.tsx
@@ -5,44 +5,28 @@ import { InputBox } from '@/components/molecule/InputBox';
 import { PhoneVerificationForm } from '@/components/molecule/PhoneVerificationForm';
 
 export function Account() {
-  const [email, setEmail] = useState('');
+  const [form, setForm] = useState({
+    email: '',
+    nickname: '',
+    phoneNumber: '',
+    password: '',
+    newPassword: '',
+  });
   const [emailMessage, setEmailMessage] = useState('');
-
-  const [nickname, setNickname] = useState('');
   const [nicknameMessage, setNicknameMessage] = useState('');
-
-  const [password, setPassword] = useState('');
   const [passwordMessage, setPasswordMessage] = useState('');
-
   const [isPasswordValid, setIsPasswordValid] = useState(false);
-
-  const [newPassword, setNewPassword] = useState('');
-
   const [newPasswordCheck, setNewPasswordCheck] = useState('');
 
-  const handleEmailChange = (value: string) => {
-    setEmail(value);
-    if (!value.includes('@')) {
-      setEmailMessage('유효한 이메일 주소를 입력해주세요.');
-    } else {
-      setEmailMessage('');
-    }
-  };
-
-  const handleNicknameChange = (value: string) => {
-    setNickname(value);
-  };
-
-  const handlePasswordChange = (value: string) => {
-    setPassword(value);
+  const handleFormChange = (id: string, value: string) => {
+    setForm({
+      ...form,
+      [id]: value,
+    });
   };
 
   const handlePasswordCheckClick = () => {
     setIsPasswordValid(!isPasswordValid);
-  };
-
-  const handleNewPasswordChange = (value: string) => {
-    setNewPassword(value);
   };
 
   const handleNewPasswordCheckChange = (value: string) => {
@@ -59,29 +43,32 @@ export function Account() {
             label="이메일"
             type="email"
             placeholder="example@gmail.com"
-            value={email}
+            value={form.email}
             validationMessage={emailMessage}
             validationMessageType="error"
-            onChange={handleEmailChange}
+            onChangeObj={handleFormChange}
           />
           <InputBox
             id="nickname"
             label="닉네임"
             placeholder="닉네임 입력"
-            value={nickname}
-            onChange={handleNicknameChange}
+            value={form.nickname}
+            onChangeObj={handleFormChange}
           />
-          <PhoneVerificationForm />
+          <PhoneVerificationForm
+            phoneNumber={form.phoneNumber}
+            onChangeObj={handleFormChange}
+          />
           <section className={styles.passwordSection}>
             <InputBox
               id="changePassword"
               label="비밀번호 변경"
               placeholder="기존 비밀번호 입력"
-              value={password}
+              value={form.password}
               buttonSize="size4"
               buttonVariant="default"
               buttonText="확인"
-              onChange={handlePasswordChange}
+              onChangeObj={handleFormChange}
               onClick={handlePasswordCheckClick}
             />
             {isPasswordValid && (
@@ -90,12 +77,12 @@ export function Account() {
                   id="newPassword"
                   label="신규 비밀번호"
                   placeholder="비밀번호 입력"
-                  value={newPassword}
-                  onChange={handleNewPasswordChange}
+                  value={form.newPassword}
+                  onChangeObj={handleFormChange}
                 />
                 <InputBox
                   id="newPasswordCheck"
-                  label="비밀번호 변경"
+                  label="신규 비밀번호 확인"
                   placeholder="기존 비밀번호 입력"
                   value={newPasswordCheck}
                   onChange={handleNewPasswordCheckChange}

--- a/frontend/src/modules/Tab/Tab.tsx
+++ b/frontend/src/modules/Tab/Tab.tsx
@@ -10,9 +10,10 @@ interface TabItem {
 interface TabProps {
   tabs: TabItem[];
   defaultActiveTab?: string;
+  onClickTab?: (tabId: string) => void;
 }
 
-export function Tab({ tabs, defaultActiveTab }: TabProps) {
+export function Tab({ tabs, defaultActiveTab, onClickTab }: TabProps) {
   const [activeTab, setActiveTab] = useState(defaultActiveTab || tabs[0].id);
 
   return (
@@ -22,7 +23,10 @@ export function Tab({ tabs, defaultActiveTab }: TabProps) {
           <button
             key={tab.id}
             className={`font-tag-1 ${styles.tabButton} ${activeTab === tab.id ? styles.active : ''}`}
-            onClick={() => setActiveTab(tab.id)}
+            onClick={() => {
+              setActiveTab(tab.id);
+              onClickTab && onClickTab(tab.id);
+            }}
           >
             {tab.label}
           </button>

--- a/frontend/src/pages/CancelPayment/CancelPayment.module.css
+++ b/frontend/src/pages/CancelPayment/CancelPayment.module.css
@@ -1,0 +1,48 @@
+.main {
+  margin: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.textarea {
+  padding: 12px;
+  box-sizing: border-box;
+  width: 100%;
+  height: 128px;
+  border-radius: 0px 12px 12px 12px;
+  border: 1px solid var(--line-less-highlight, #c9c9c9);
+  background: var(--box-default, #fbfbfb);
+  color: var(--text-sub, #767676);
+}
+
+.textareaLength {
+  margin-top: 5px;
+  margin-left: 6px;
+  color: var(--text-guidetext, #a7a7a7);
+}
+
+.selectedImageWrapper {
+  display: flex;
+  position: relative;
+}
+
+.selectedImage {
+  position: relative;
+  display: inline-block;
+  width: 80px;
+  height: 77px;
+}
+
+.removeBtn {
+  position: absolute;
+  top: -8px;
+  left: 72px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+}
+
+.bottomBtn {
+  margin-top: 20px;
+}

--- a/frontend/src/pages/CancelPayment/CancelPayment.tsx
+++ b/frontend/src/pages/CancelPayment/CancelPayment.tsx
@@ -1,5 +1,112 @@
+import { InputBox } from '@/components/molecule/InputBox';
 import styles from './CancelPayment.module.css';
+import { ChangeEvent, useRef, useState } from 'react';
+import { Button, Label } from '@/components/atom';
+import RemoveIcon from '@/assets/icons/remove.svg?react';
 
 export function CancelPayment() {
-  return <></>;
+  const [form, setForm] = useState({
+    title: '',
+    email: '',
+    phoneNumber: '',
+    content: '',
+  });
+
+  const handleFormChange = (id: string, value: string) => {
+    setForm({
+      ...form,
+      [id]: value,
+    });
+  };
+
+  const [selectedImage, setSelectedImage] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleImageChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      setSelectedImage(URL.createObjectURL(file));
+    }
+  };
+
+  const handleButtonClick = () => {
+    inputRef.current?.click();
+  };
+
+  const handleRemoveImage = () => {
+    setSelectedImage(null);
+    if (inputRef.current) {
+      inputRef.current.value = '';
+    }
+  };
+
+  return (
+    <>
+      <main className={styles.main}>
+        <InputBox
+          id="title"
+          label="제목"
+          placeholder="제목을 입력해주세요"
+          value={form.title}
+          onChangeObj={handleFormChange}
+        />
+        <InputBox
+          id="email"
+          label="이메일"
+          type="email"
+          placeholder="이메일을 입력해주세요"
+          value={form.email}
+          onChangeObj={handleFormChange}
+        />
+        <InputBox
+          id="phoneNumber"
+          label="연락처"
+          placeholder="연락처를 입력해주세요"
+          value={form.phoneNumber}
+          onChangeObj={handleFormChange}
+        />
+        <div>
+          <Label label="문의내용" id="content" />
+          <textarea
+            id="content"
+            value={form.content}
+            onChange={(e) => handleFormChange(e.target.id, e.target.value)}
+            placeholder="문의내용을 입력해주세요"
+            className={`${styles.textarea} font-guidetext`}
+            maxLength={1000}
+            rows={1}
+          />
+          <div className={`${styles.textareaLength} font-guidetext`}>
+            {form.content.length}/1000
+          </div>
+        </div>
+        <div className="font-text-2">
+          사진을 첨부해주시면, 더욱 빠르고 정확한 도움을 드릴 수 있습니다.
+        </div>
+        <input
+          type="file"
+          accept="image/*"
+          onChange={handleImageChange}
+          style={{ display: 'none' }}
+          ref={inputRef}
+        />
+        <Button size="size2" variant="plus_icon" onClick={handleButtonClick}>
+          사진 업로드
+        </Button>
+        {selectedImage && (
+          <div className={styles.selectedImageWrapper}>
+            <img
+              src={selectedImage}
+              alt="Selected"
+              className={styles.selectedImage}
+            />
+            <button onClick={handleRemoveImage} className={styles.removeBtn}>
+              <RemoveIcon />
+            </button>
+          </div>
+        )}
+        <Button className={styles.bottomBtn}>접수하기</Button>
+      </main>
+    </>
+  );
 }

--- a/frontend/src/pages/Mypage/Mypage.tsx
+++ b/frontend/src/pages/Mypage/Mypage.tsx
@@ -4,8 +4,12 @@ import { Tab } from '@/modules';
 import { Account } from '@/components/organism';
 import { Subscription } from '@/components/organism/Subscription';
 import { PaymentHistory } from '@/components/organism/PaymentHistory';
+import { useNavigate, useParams } from 'react-router-dom';
 
 export function Mypage() {
+  const { tab } = useParams();
+  const navigate = useNavigate();
+
   const tabs = [
     {
       id: 'account',
@@ -36,7 +40,11 @@ export function Mypage() {
         </div>
       </div>
 
-      <Tab tabs={tabs} defaultActiveTab="account" />
+      <Tab
+        tabs={tabs}
+        defaultActiveTab={tab}
+        onClickTab={(tabId) => navigate(`/mypage/${tabId}`, { replace: true })}
+      />
     </>
   );
 }

--- a/frontend/src/stories/Button.stories.ts
+++ b/frontend/src/stories/Button.stories.ts
@@ -47,7 +47,7 @@ export const Default: Story = {
 
 export const PlusIcon: Story = {
   args: {
-    children: '+ Add Item',
+    children: 'Add Item',
     size: 'size2',
     variant: 'plus_icon',
   },

--- a/frontend/src/stories/Button.tsx
+++ b/frontend/src/stories/Button.tsx
@@ -1,6 +1,7 @@
 // Button.tsx
 import React from 'react';
 import styles from './Button.module.css';
+import PlusIcon from '@/assets/icons/plus.svg?react';
 
 type ButtonSize = 'size1' | 'size2' | 'size3' | 'size4';
 type ButtonVariant =
@@ -30,6 +31,7 @@ export function Button({
 
   return (
     <button className={buttonClass} {...props}>
+      {variant === 'plus_icon' && <PlusIcon />}
       {children}
     </button>
   );


### PR DESCRIPTION
## 변경사항 설명
- mypage > 결제 내역 탭 > 결제 취소 UI 구현
- mypage Route tab 파라미터 추가(/mypage > /mypage/:tab) => 결제 취소 화면에서 뒤로가기 시 결제 내역 탭으로 연결하기 위함
- mypage 내에서 tab 이동 시 히스토리에 남지 않게 replace 속성 이용 => tab 이동 후 뒤로가기 시 이전 페이지로 연결하기 위함
- button component의 plus_icon 수정
- input component에 onChangeObj 속성 추가(기존에 작업했던 마이페이지 계정 관리 탭 리팩토링)

## 관련 이슈
Closes #45

## 변경 유형
<!-- 해당하는 항목에 x 표시를 해주세요 -->
- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 성능 개선
- [ ] 코드 스타일 업데이트 (포맷팅, 변수명 등)
- [x] 리팩토링 (기능적 변경 없음)
- [ ] 문서 내용 변경
- [ ] 종속성 업데이트
- [ ] CI/CD 파이프라인 변경
- [ ] 기타 (설명해주세요):

## 미리보기
<img src="https://github.com/user-attachments/assets/8f043835-188f-4b00-a781-fc2763ac650e" width="50%">

