### PR TITLE
feat: 결제 이후의 리다이렉션 기능 구현

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -77,6 +77,16 @@ class Settings(BaseSettings):
     GEMINI_API_KEY: str
     GEMINI_API_URL: str
 
+    KAKAO_PAY_BASE_URL: str
+    KAKAO_PAY_CID_ONE: str
+    KAKAO_PAY_CID_SUB: str
+    KAKAO_PAY_CID_SEQ: str
+    KAKAO_PAY_SECRET_KEY: str
+    PAYMENT_URL: str
+    KAKAO_PAY_SUCCESS: str
+    KAKAO_PAY_CANCEL: str
+    KAKAO_PAY_FAIL: str
+
     class Config:
         env_file = ".env"
 

--- a/backend/app/domains/payment/schemas.py
+++ b/backend/app/domains/payment/schemas.py
@@ -160,7 +160,7 @@ class SequentialPaymentMethod(BaseModel):
     payment_priority: int
     sid: str
     payment_method_type: str
-    card_info: Optional[CardInfo] = None  # 선택 사항, 카드 결제일 경우
+    card_info: Optional[CardInfo] = None
 
 class KakaoPayApproval(BaseModel):
     tid: str
@@ -177,6 +177,15 @@ class KakaoPayApproval(BaseModel):
     sequential_payment_methods: Optional[List[SequentialPaymentMethod]] = None  # 정기 결제 시 순차결제일 경우
     created_at: datetime
     approved_at: datetime
+
+class KakaoPayFailureExtras(BaseModel):
+    method_result_code: Optional[str] = Field(None, description="카카오페이 실패 상세 코드")
+    method_result_message: Optional[str] = Field(None, description="카카오페이 실패 상세 메시지")
+
+class KakaoPayFailureResponse(BaseModel):
+    error_code: int = Field(..., description="카카오페이 실패 코드")
+    error_message: str = Field(..., description="카카오페이 실패 메시지")
+    extras: Optional[KakaoPayFailureExtras] = Field(None, description="추가 실패 정보")
 
 # admin 
 class AdminPaymentCreate(BaseModel):


### PR DESCRIPTION
## 변경사항 설명
카카오 페이 결제 이후 성공, 실패, 취소 상황에 맞게 프론트 엔드 페이지로 리다이렉션 하도록 구현
결제 관련 환경변수. core/config.py 에  추가 [기존 os로 직접 로드에서 settings 메서드로 변경]

## 관련 이슈
<!-- 이 PR과 관련된 이슈 번호를 적어주세요. 예: #123, #456 -->
Closes #

## 변경 유형
<!-- 해당하는 항목에 x 표시를 해주세요 -->
- [ ] 버그 수정
- [x] 새로운 기능
- [ ] 성능 개선
- [ ] 코드 스타일 업데이트 (포맷팅, 변수명 등)
- [x] 리팩토링 (기능적 변경 없음)
- [ ] 문서 내용 변경
- [ ] 종속성 업데이트
- [ ] CI/CD 파이프라인 변경
- [ ] 기타 (설명해주세요):

## 미리보기
<!-- 변경사항을 시각적으로 보여줄 수 있는 스크린샷, GIF, 또는 비디오를 추가해주세요 -->

## 리뷰 요청사항
<!-- 리뷰어에게 특별히 확인받고 싶은 부분이 있다면 여기에 명시해주세요 -->
- 
- 
